### PR TITLE
Simplifying start.sh

### DIFF
--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -108,6 +108,10 @@ fi
 # Launch the IOC ***************************************************************
 
 if [[ ${TARGET_ARCHITECTURE} == "rtems" ]] ; then
+
+    # this mount point is defined in helm-ioc-lib _deployment.yaml
+    K8S_IOC_ROOT=/nfsv2-tftp
+
     echo "RTEMS IOC (base). Copying IOCs file to RTEMS mount point ..."
     rm -rf ${K8S_IOC_ROOT}/*
     cp -r ${IOC}/* ${K8S_IOC_ROOT}


### PR DESCRIPTION
remove requirement for K8S_IOC_ROOT as the mount point it represents is hard coded in helm-ioc-lib and not supplying it causes confusing errors.