### PR TITLE
Fix entry point

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -52,5 +52,4 @@ COPY --from=runtime_prep /assets /
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
-CMD "bash -c ${IOC}/start.sh"
-
+CMD ["bash", "-c", "${IOC}/start.sh"]


### PR DESCRIPTION
This fixes the entry point which fails with `/bin/sh: 1: bash -c /epics/ioc/start.sh: not found`

This change is inline with `ioc-adsimdetector` which already works as desired: https://github.com/epics-containers/ioc-adsimdetector/blob/3996868e07fc9d561689cdead08d29c490e221f5/Dockerfile#L72C1-L72C38