### PR TITLE
isolate devcontainer and test container networks

### DIFF
--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
     "runArgs": [
         // IMPORTANT: this network must exist before the container is created
         // source compose/environment.sh to create it before first use
-        "--network=channel_access",
+        "--network=channel_access_devcontainer",
         // Make sure SELinux does not disable write access to host filesystems like tmp
         "--security-opt=label=disable"
     ],

--- a/template/compose/environment.sh
+++ b/template/compose/environment.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # make sure we have a network to share beteen the devcontainer and gateway container
-if ! docker network exists channel_access ; then
-    docker network create --subnet="170.20.0.0/16" channel_access
+if ! docker network inspect channel_access_devcontainer &>/dev/null ; then
+    docker network create --subnet="170.21.0.0/16" channel_access_devcontainer
 fi
 
 # ensure local container users can access X11 server

--- a/template/compose/services/gateway/compose.yml
+++ b/template/compose/services/gateway/compose.yml
@@ -22,13 +22,13 @@ services:
     restart: unless-stopped
 
     networks:
-      channel_access:
+      channel_access_devcontainer:
 
     configs:
       - source: ca-gateway_config
         target: /config
 
-    command: -cip 170.20.255.255 -pvlist /config/pvlist -access /config/access -log /dev/stdout -debug 1
+    command: -cip 170.21.255.255 -pvlist /config/pvlist -access /config/access -log /dev/stdout -debug 1
 
     profiles:
       - test
@@ -50,5 +50,5 @@ configs:
     file: ./config
 
 networks:
-  channel_access:
+  channel_access_devcontainer:
     external: true


### PR DESCRIPTION
This way compose can control the test network and the devcontainer network can live indefinitely.
Also - podman test compose up was not working with the ./envirnonment created network for some reason.
