### PR TITLE
Fix compose env

### DIFF
--- a/template/compose/environment.sh
+++ b/template/compose/environment.sh
@@ -30,14 +30,16 @@ function check_docker {
 
 if check_docker; then
     USER_ID=$(id -u); USER_GID=$(id -g)
+    docker="docker"
 else
     USER_ID=0; USER_GID=0
     alias docker=podman
+    docker="podman"
 fi
 
 # make sure we have a network to share beteen the devcontainer and gateway container
-if ! docker network inspect channel_access_devcontainer &>/dev/null ; then
-    docker network create --subnet="170.21.0.0/16" channel_access_devcontainer
+if ! $docker network inspect channel_access_devcontainer &>/dev/null ; then
+    $docker network create --subnet="170.21.0.0/16" channel_access_devcontainer
 fi
 
 # ensure local container users can access X11 server

--- a/template/compose/environment.sh
+++ b/template/compose/environment.sh
@@ -52,4 +52,4 @@ export COMPOSE_PROFILES=test
 # for test profile our ca-gateway publishes PVS on the loopback interface
 export EPICS_CA_ADDR_LIST=127.0.0.1
 # make a short alias for docker-compose for convenience
-alias ec='docker compose'
+alias dc='docker compose'


### PR DESCRIPTION
fixes #20 I test this by first disabling alias expansion, seeing that it breaks, and then applying the changes and seeing that it works
```
[esq51579@pc0146 ioc-template]$ shopt -u expand_aliases  # Disable alias expansion
[esq51579@pc0146 ioc-template]$ source template/compose/environment.sh 
bash: docker: command not found
localuser:esq51579 being added to access control list
[esq51579@pc0146 ioc-template]$ git stash pop
On branch fix-compose-env
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   template/compose/environment.sh

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (475be9c1a11c6ef4c227234c8abc2e1825db6858)
[esq51579@pc0146 ioc-template]$ source template/compose/environment.sh 
channel_access_devcontainer
localuser:esq51579 being added to access control list
```