### PR TITLE
Revert "update submodule in devcontainer init"

### DIFF
--- a/template/.devcontainer/initializeCommand
+++ b/template/.devcontainer/initializeCommand
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # custom initialization goes here - runs outside of the dev container
-# just before the container is created
-
-# make sure ibek-support is in place or the container build will fail
-git submodule update --init --recursive
+# just before the container is launched but after the container is created
 
 echo "initializeCommand for devcontainerID ${1}"
 set -xe


### PR DESCRIPTION
Not a good change - it means that your local submodule changes would be silently removed on a devcontainer rebuild.

This reverts commit 5ddbdedd4e3d2ec1d34b77c8a5b6d4256692a0e0.