### PR TITLE
start.sh: first-class runtime artifact placement (de-fork support)

### DIFF
--- a/template/ioc/start.sh
+++ b/template/ioc/start.sh
@@ -58,8 +58,10 @@ if [[ -f ${CONFIG_DIR}/ioc.yaml ]] ; then
 fi
 
 # build expanded database using msi ********************************************
+# the instance config folder is on the include path so that runtime-support
+# patterns can supply their own .template / .db files alongside ioc.yaml.
 if [ -f ${RUNTIME_DIR}/ioc.subst ]; then
-    includes=$(for i in ${SUPPORT}/*/db; do echo -n "-I $i "; done)
+    includes=$(for i in ${SUPPORT}/*/db ${CONFIG_DIR}; do echo -n "-I $i "; done)
     bash -c "msi -o${RUNTIME_DIR}/ioc.db ${includes} -I${RUNTIME_DIR} -S${RUNTIME_DIR}/ioc.subst"
 fi
 
@@ -68,6 +70,15 @@ fi
 if [[ -d /epics/support/configure/protocol ]] ; then
     rm -fr ${RUNTIME_DIR}/protocol
     cp -r /epics/support/configure/protocol  ${RUNTIME_DIR}
+fi
+
+# place runtime artifacts declared in the instance config folder **************
+# proto/db files vendored or dropped into config/ (e.g. by `ibek pattern add`)
+# are copied into their runtime search-path locations. Runs after the support
+# protocol copy above so instance files are added alongside, not wiped. This
+# replaces the per-image start.sh fork (epics-containers/ioc-streamdevice#1).
+if [[ -f ${CONFIG_DIR}/ioc.yaml ]] ; then
+    ibek runtime place-files ${CONFIG_DIR}
 fi
 
 # check hardware communication pre-requisites **********************************

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,4 +1,4 @@
-ibek>=3.3.4
+ibek>=4.6.1
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets
 stdio-socket>=1.4.0


### PR DESCRIPTION
## Summary

Generalises the standard generic-IOC `start.sh` so runtime-support patterns work with **no per-image `start.sh` fork**. This is the upstream half of the de-fork in epics-containers/ioc-streamdevice#1 (its PR epics-containers/ioc-streamdevice#2 deletes the fork and relies on this).

Part of the runtime-pattern-vendoring rollout (keystone: epics-containers/ibek#354 / issue #353).

## What changed (`template/ioc/start.sh`)

1. **Instance config folder on the msi include path** — `${CONFIG_DIR}` is added to the `msi -I` list so a vendored pattern may supply its own `.template` / `.db` files alongside `ioc.yaml`. Previously only `${SUPPORT}/*/db` was searched, so instance-local templates were invisible to `msi`.
2. **First-class runtime artifact placement** — a new step `ibek runtime place-files ${CONFIG_DIR}` copies declared runtime artifacts (`*.proto`/`*.protocol` → runtime protocol dir, `*.db`/`*.template` → runtime db dir) from `config/` into their boot search-path locations. It runs **after** the support-module protocol copy (which does `rm -fr ${RUNTIME_DIR}/protocol`) so instance protos are added alongside support protos rather than wiped.

`ibek runtime place-files` is provided by epics-containers/ibek#354.

## Why

`ioc-streamdevice` had hand-patched both of these into its own `start.sh` (a `##### CUSTOM STEP` proto-copy block plus a `/epics/ioc/config` msi include) — maintenance debt re-applied on every template update. Upstreaming them here makes the behaviour generic for **any** generic IOC that carries runtime artifacts in `config/`, and lets `ioc-streamdevice/ioc/start.sh` become byte-identical to this template again (no fork to re-merge on `copier update`).

## Validation

- `bash -n` clean.
- Ordering verified against `ibek runtime generate2` (which `rmtree`s `${RUNTIME_DIR}` first) and the support-protocol copy, so placed files survive to IOC launch.
- End-to-end exercised by the streamdevice de-fork (epics-containers/ioc-streamdevice#2) and the t01-services adoption (gilesknap/t01-services#10).

## Dependency

Requires an `ibek` that ships `ibek runtime place-files` (epics-containers/ibek#354). Until that releases, generic-IOC images built from this template must carry that ibek.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime startup now places additional instance-specific files automatically, making configured resources available without extra setup.

* **Chores**
  * Updated the minimum supported version of a core runtime dependency.
  * Added support for a new socket-related dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->