### PR TITLE
adding genearte manifest feature (create versions.json release asset)

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -11,13 +11,16 @@ ARG DEVELOPER=${REGISTRY}/epics-base${IMAGE_EXT}-developer:7.0.9ec5
 ##### build stage ##############################################################
 FROM  ${DEVELOPER} AS developer
 
+# initiate ioc image verson variable for manifest
+ARG IOC_VERSION=unknown
+
 # The devcontainer mounts the project root to /epics/generic-source
 # Using the same location here makes devcontainer/runtime differences transparent.
 ENV SOURCE_FOLDER=/epics/generic-source
 # connect ioc source folder to its know location
 RUN ln -s ${SOURCE_FOLDER}/ioc ${IOC}
 
-# Get the current version of ibek
+# get the current versions of pvi and ibek
 COPY requirements.txt requirements.txt
 RUN uv pip install --upgrade -r requirements.txt
 
@@ -38,6 +41,10 @@ RUN ansible.sh autosave
 # get the ioc source and build it
 COPY ioc ${SOURCE_FOLDER}/ioc
 RUN ansible.sh ioc
+
+# generate a manifest of installed EPICS modules and python packages
+COPY scripts/generate_manifest.py /tmp/generate_manifest.py
+RUN python3 /tmp/generate_manifest.py "${IOC_VERSION}"
 
 ##### runtime preparation stage ################################################
 FROM developer AS runtime_prep

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,4 +1,6 @@
-ibek>=4.6.1
+# pin versions of pvi or ibek if needed
+pvi
+ibek
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets
 stdio-socket>=1.4.0

--- a/template/scripts/generate_manifest.py
+++ b/template/scripts/generate_manifest.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Scrape installed EPICS support module versions and Python package versions
+into a single JSON manifest, for publishing alongside the IOC schema on
+each tagged GitHub Release.
+"""
+import json
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# use ruamel.yaml from ibek
+from ruamel.yaml import YAML
+from ruamel.yaml.error import YAMLError
+
+IBEK_SUPPORT_ROOT = pathlib.Path("/epics/generic-source/ibek-support")
+OUTPUT_PATH = pathlib.Path("/epics/versions.json")
+
+_yaml = YAML(typ="safe")
+
+# mirrors the default in ibek-support's _ansible/roles/support/vars/main.yml:
+#   organization: https://github.com/epics-modules
+DEFAULT_ORGANIZATION = "https://github.com/epics-modules"
+
+##########
+
+
+def _looks_like_commit_sha(version: str) -> bool:
+    """full or short git commit SHAs are 7-40 lowercase hex chars."""
+    return 7 <= len(version) <= 40 and all(c in "0123456789abcdef" for c in version.lower())
+
+
+def get_epics_modules(root: pathlib.Path) -> dict:
+
+    modules = {}
+
+    # look though all install.yml files in ibek-support built in the dependency tree
+    for filepath in sorted(root.rglob("*.install.yml")):
+
+        try:
+            data = _yaml.load(filepath.read_text())
+
+        except YAMLError as e:
+            print(f"warning: could not parse {filepath}: {e}", file=sys.stderr)
+            continue
+
+        if not data:
+            continue
+
+        name = data.get("module") or filepath.stem.replace(".install", "")
+        version = data.get("version", "unknown")
+        organization = data.get("organization", DEFAULT_ORGANIZATION)
+        git_repo = data.get("git_repo") or f"{organization.rstrip('/')}/{name}"
+
+        modules[name] = {
+            "version": version,
+            "organization": organization,
+            "git-repo": git_repo,
+            "pinned-to-commit": _looks_like_commit_sha(version), # identify when pinned to a commit and not an actual release
+        }
+
+    return modules
+
+
+def get_python_packages() -> dict:
+
+    # explicitly target the interpreter running this script
+    out = subprocess.check_output(
+        ["uv", "pip", "list", "--python", sys.executable, "--format=json"]
+    )
+
+    packages = {p["name"]: p["version"] for p in json.loads(out)}
+
+    return packages
+
+
+def main() -> None:
+    ioc_version = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+
+    manifest = {
+        "ioc-version": ioc_version,
+        "generated-at": datetime.now(timezone.utc).isoformat(),
+        "epics-modules": get_epics_modules(IBEK_SUPPORT_ROOT),
+        "python-packages": get_python_packages(),
+    }
+
+    OUTPUT_PATH.write_text(json.dumps(manifest, indent=2))
+
+    print(
+        f"wrote manifest with {len(manifest['epics-modules'])} EPICS modules "
+        f"and {len(manifest['python-packages'])} python packages to {OUTPUT_PATH}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/template/{% if  git_platform == 'github.com' %}.github{% endif %}/workflows/build.yml.jinja
+++ b/template/{% if  git_platform == 'github.com' %}.github{% endif %}/workflows/build.yml.jinja
@@ -62,6 +62,7 @@ jobs:
           target: runtime
           build-args: |
             IMAGE_EXT=${{ matrix.extension }}
+            IOC_VERSION=${{ github.ref_name }}
           cache-from: type=gha,scope=${{ matrix.epics-target }}
           cache-to: type=gha,mode=max,scope=${{ matrix.epics-target }}
           tags: ci_test
@@ -90,6 +91,7 @@ jobs:
           target: developer
           build-args: |
             IMAGE_EXT=${{ matrix.extension }}
+            IOC_VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta-developer.outputs.tags }}
           labels: ${{ steps.meta-developer.outputs.labels }}
           push: true
@@ -134,6 +136,10 @@ jobs:
       - name: generate-schema
         run: |
           ibek ioc generate-schema --output ibek.ioc.schema.json
+
+      - name: copy versions manifest
+        run: |
+          cp /epics/versions.json versions.json
 
       - name: Github Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15


### PR DESCRIPTION
Copying generate manifest feature from ioc-aduvc to the template. The feature is discussed and tested on this PR:

https://github.com/epics-containers/ioc-aduvc/pull/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a generated version manifest to builds, capturing installed EPICS modules and Python packages.
  * Release artifacts now include a versions file alongside the existing schema output.

* **Chores**
  * Build and release processes now pass the current IOC version through to image creation.
  * Dependency list updates were made to keep packaging aligned with the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->